### PR TITLE
Remove duplicate event registration in constructor of 'DiscordMain'

### DIFF
--- a/src/main/java/com/shadowolfyt/zander/discord/DiscordMain.java
+++ b/src/main/java/com/shadowolfyt/zander/discord/DiscordMain.java
@@ -30,7 +30,6 @@ public class DiscordMain extends ListenerAdapter implements Listener {
     public DiscordMain (ZanderMain instance) {
         plugin = instance;
         startBot();
-        plugin.getServer().getPluginManager().registerEvents(this, plugin);
         jda.addEventListener(this);
     }
 


### PR DESCRIPTION
DiscordMain.java - line 33
is the same as
ZanderMain.java - line 42
results in duplicate discord message being sent.